### PR TITLE
[BREAKING] Rename truncation strategy to deletion.

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,39 +19,36 @@ end
 
 ## Supported Strategies
 
-<table>
-  <tbody>
-    <tr>
-      <th>Truncation</th>
-      <th>Transaction</th>
-      <th>Deletion</th>
-    </tr>
-    <tr>
-      <td> <b>Yes</b></td>
-      <td> No</td>
-      <td> No</td>
-    </tr>
-  </tbody>
-</table>
+The mongoid adapter only has one strategy: the deletion strategy.
 
-(Default strategy is denoted in bold)
+## Strategy configuration options
 
-## Configuration options
+`:only` and `:except` may take a list of collection names:
 
-<table>
-  <tbody>
-    <tr>
-      <th>ORM</th>
-      <th>How to access</th>
-      <th>Notes</th>
-    </tr>
-    <tr>
-      <td> Mongoid</td>
-      <td> <code>DatabaseCleaner[:mongoid]</code></td>
-      <td> Multiple databases supported for Mongoid 3. Specify <code>DatabaseCleaner[:mongoid, {:connection =&gt; :db_name}]</code> </td>
-    </tr>
-  </tbody>
-</table>
+```ruby
+# Only delete the "users" collection.
+DatabaseCleaner[:mongoid].strategy = :deletion, { only: ["users"] }
+
+# Delete all collections except the "users" collection.
+DatabaseCleaner[:mongoid].strategy = :deletion, { except: ["users"] }
+```
+
+## Adapter configuration options
+
+`#db` defaults to the default Mongoid database, but can be specified manually in a few ways:
+
+```ruby
+# Redis URI string:
+DatabaseCleaner[:mongoid].db = :logs
+
+# Back to default:
+DatabaseCleaner[:mongoid].db = :default
+
+# Multiple Mongoid databases can be specified:
+DatabaseCleaner[:mongoid, connection: :default]
+DatabaseCleaner[:mongoid, connection: :shard_1]
+DatabaseCleaner[:mongoid, connection: :shard_2]
+```
 
 ## COPYRIGHT
 

--- a/lib/database_cleaner/mongoid.rb
+++ b/lib/database_cleaner/mongoid.rb
@@ -1,5 +1,5 @@
 require "database_cleaner/mongoid/version"
 require "database_cleaner/core"
-require "database_cleaner/mongoid/truncation"
+require "database_cleaner/mongoid/deletion"
 
-DatabaseCleaner[:mongoid].strategy = :truncation
+DatabaseCleaner[:mongoid].strategy = :deletion

--- a/lib/database_cleaner/mongoid/deletion.rb
+++ b/lib/database_cleaner/mongoid/deletion.rb
@@ -1,20 +1,20 @@
 require 'database_cleaner/strategy'
-require 'database_cleaner/mongoid/mongoid4_truncation_mixin'
-require 'database_cleaner/mongoid/mongoid5_truncation_mixin'
+require 'database_cleaner/mongoid/mongoid4_mixin'
+require 'database_cleaner/mongoid/mongoid5_mixin'
 require 'mongoid/version'
 
 module DatabaseCleaner
   module Mongoid
-    class Truncation < Strategy
-      if ::Mongoid::VERSION < '5'
-        include ::DatabaseCleaner::Mongoid::Mongoid4TruncationMixin
-      else
-        include ::DatabaseCleaner::Mongoid::Mongoid5TruncationMixin
-      end
-
+    class Deletion < Strategy
       def initialize only: [], except: []
         @only = only
         @except = except
+      end
+
+      if ::Mongoid::VERSION < '5'
+        include ::DatabaseCleaner::Mongoid::Mongoid4Mixin
+      else
+        include ::DatabaseCleaner::Mongoid::Mongoid5Mixin
       end
 
       private

--- a/lib/database_cleaner/mongoid/mongoid4_mixin.rb
+++ b/lib/database_cleaner/mongoid/mongoid4_mixin.rb
@@ -1,6 +1,6 @@
 module DatabaseCleaner
   module Mongoid
-    module Mongoid4TruncationMixin
+    module Mongoid4Mixin
       def clean
         collections_to_delete.each(&:remove_all)
         wait_for_removals_to_finish

--- a/lib/database_cleaner/mongoid/mongoid5_mixin.rb
+++ b/lib/database_cleaner/mongoid/mongoid5_mixin.rb
@@ -1,6 +1,6 @@
 module DatabaseCleaner
   module Mongoid
-    module Mongoid5TruncationMixin
+    module Mongoid5Mixin
       def clean
         collections_to_delete.each(&:delete_many)
       end

--- a/spec/database_cleaner/mongoid/deletion_spec.rb
+++ b/spec/database_cleaner/mongoid/deletion_spec.rb
@@ -1,7 +1,7 @@
 require 'support/mongoid_helper'
-require 'database_cleaner/mongoid/truncation'
+require 'database_cleaner/mongoid/deletion'
 
-RSpec.describe DatabaseCleaner::Mongoid::Truncation do
+RSpec.describe DatabaseCleaner::Mongoid::Deletion do
   subject(:strategy) { described_class.new }
 
   describe '#clean' do
@@ -11,21 +11,21 @@ RSpec.describe DatabaseCleaner::Mongoid::Truncation do
         2.times { Agent.create! }
       end
 
-      it "should truncate all tables" do
+      it "should delete all collections" do
         expect { strategy.clean }
           .to change { [User.count, Agent.count] }
           .from([2,2])
           .to([0,0])
       end
 
-      it "should only truncate the tables specified in the :only option when provided" do
+      it "should only delete the collections specified in the :only option when provided" do
         expect { described_class.new(only: ['agents']).clean }
           .to change { [User.count, Agent.count] }
           .from([2,2])
           .to([2,0])
       end
 
-      it "should not truncate the tables specified in the :except option" do
+      it "should not delete the collections specified in the :except option" do
         expect { described_class.new(except: ['users']).clean }
           .to change { [User.count, Agent.count] }
           .from([2,2])


### PR DESCRIPTION
Mongoid actually _does_ have a truncate command, and it might make sense to build a strategy around it! However, Mongoid method actually being invoked here is named `delete_many`, so I think this makes sense.

Will need to add deprecation warnings to 1.99 for this transition.

Also, I fixed up the configuration docs in the README while I was at it.